### PR TITLE
Added workaround to allow all origins required as per bug 11750

### DIFF
--- a/src/test/java/Tests/DriverFactory.java
+++ b/src/test/java/Tests/DriverFactory.java
@@ -3,6 +3,7 @@ package Tests;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 
 public class DriverFactory {
 
@@ -20,7 +21,9 @@ public class DriverFactory {
     }
 
     private void setDriver() {
-        driver = new ChromeDriver();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--remote-allow-origins=*");
+        driver = new ChromeDriver(options);
         driver.manage().window().maximize();
     }
 


### PR DESCRIPTION
Changes to chrome 111 has meant that the previously default setting for allowing all remote origins is now set to local host resulting in a 403 forbidden in the tests, as noted in the bug raised with Selenium [Bug ID 11750](https://github.com/SeleniumHQ/selenium/issues/11750) 

This change adds in chromeoptions and sets remote allow origins to wildcard * as per default previously

No other changes required