### PR TITLE
Update selenium version bug 11750

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.4.0</version>
+            <version>4.9.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.3.0</version>
+            <version>5.3.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Changes to chrome 111 has meant that the previously default setting for allowing all remote origins is now set to local host resulting in a 403 forbidden in the tests, as noted in the bug raised with Selenium https://github.com/SeleniumHQ/selenium/issues/11750

This change updates the relevant dependencies

- (Required) Updated Selenium-Java version from 4.4.0 to 4.9.0
- (Additional) Updated WebDriverManager version from 5.3.0 to 5.3.2

This supersedes PR https://github.com/ten10solutions/Junit-Selenium-Boilerplate/pull/2

No other changes required