### PR TITLE
Force clear driver cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.9.0</version>
+            <version>4.15.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.3.2</version>
+            <version>5.6.2</version>
         </dependency>
     </dependencies>
 

--- a/src/test/java/Tests/DriverFactory.java
+++ b/src/test/java/Tests/DriverFactory.java
@@ -7,7 +7,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 public class DriverFactory {
 
     static {
-        WebDriverManager.chromedriver().setup();
+        WebDriverManager.chromedriver().clearDriverCache().setup();
     }
 
     private WebDriver driver;


### PR DESCRIPTION
Two updates
1. Update dependencies for selenium and WebDriverManager
2. Added clearDriverCache before setting up chromedriver to avoid previous compatibility issues with chromedriver bin storage

Tested locally and runs as normal, preventative fix