### PR TITLE
Updated version of WebDriverManager dependency from v5.6.2 to 5.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.6.2</version>
+            <version>5.6.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Updated version of WebDriverManager dependency from v5.6.2 to 5.6.4 to fix issue https://github.com/bonigarcia/webdrivermanager/issues/1226 